### PR TITLE
Generalising the way that services can be tested for extendability

### DIFF
--- a/tests/running_services.bats
+++ b/tests/running_services.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+# This file provides a generic way of verifying a service is running
+# to run this create a link to the file with the service name
+# i.e. httpd.bats
+
+service="$( basename $BATS_TEST_FILENAME | awk -F'.bats' '{ print $1 }' )
+if [  $( basename $BATS_TEST_FILENAME ) == 'running_services.bats' ]
+then
+  return
+fi
+
+@test "Is $service service running?" {
+  if [ -e '/usr/bin/systemctl' ]
+  then
+    run systemctl status $service
+  else
+    run service $service status
+  fi 
+  [ "$status" -eq 0 ]
+}

--- a/tests/running_services.bats
+++ b/tests/running_services.bats
@@ -3,7 +3,7 @@
 # to run this create a link to the file with the service name
 # i.e. httpd.bats
 
-service=$( basename "${BATS_TEST_FILENAME}" .bats
+service=$( basename "${BATS_TEST_FILENAME}" .bats )
 if [  $( basename "${BATS_TEST_FILENAME}" ) == 'running_services.bats' ]
 then
   return

--- a/tests/running_services.bats
+++ b/tests/running_services.bats
@@ -3,8 +3,8 @@
 # to run this create a link to the file with the service name
 # i.e. httpd.bats
 
-service="$( basename $BATS_TEST_FILENAME | awk -F'.bats' '{ print $1 }' )
-if [  $( basename $BATS_TEST_FILENAME ) == 'running_services.bats' ]
+service=$( basename "${BATS_TEST_FILENAME}" .bats
+if [  $( basename "${BATS_TEST_FILENAME}" ) == 'running_services.bats' ]
 then
   return
 fi
@@ -12,9 +12,9 @@ fi
 @test "Is $service service running?" {
   if [ -e '/usr/bin/systemctl' ]
   then
-    run systemctl status $service
+    run systemctl status "$service"
   else
-    run service $service status
+    run service "$service" status
   fi 
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
If we generalise the way that tests run, services enabled, packages installed, content checked, we will be able from a server definition that contains  a list of the above, to check that each of those are valid without much programmatic input. This is an example of a generalised test. 
To use it simply link the name of the service e.g  "ntpd.bats" to the file and run.